### PR TITLE
[doc] Update CI workflow's name to fix CI badge

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Continuous Integration
 on: [push, pull_request]
 
 jobs:

--- a/relational_types_procmacro_tests/tests/02-invalid-weight.rs
+++ b/relational_types_procmacro_tests/tests/02-invalid-weight.rs
@@ -2,7 +2,6 @@ mod test_utils;
 
 use relational_types::*;
 use test_utils::*;
-use typed_index_collection::*;
 
 #[derive(GetCorresponding)]
 pub struct Model {

--- a/relational_types_procmacro_tests/tests/02-invalid-weight.stderr
+++ b/relational_types_procmacro_tests/tests/02-invalid-weight.stderr
@@ -1,7 +1,7 @@
 error: proc-macro derive panicked
- --> $DIR/02-invalid-weight.rs:7:10
+ --> $DIR/02-invalid-weight.rs:6:10
   |
-7 | #[derive(GetCorresponding)]
+6 | #[derive(GetCorresponding)]
   |          ^^^^^^^^^^^^^^^^
   |
   = help: message: `weight` attribute must be convertible to f64: ParseFloatError { kind: Invalid }

--- a/relational_types_procmacro_tests/tests/03-non-supported-argument.rs
+++ b/relational_types_procmacro_tests/tests/03-non-supported-argument.rs
@@ -2,7 +2,6 @@ mod test_utils;
 
 use relational_types::*;
 use test_utils::*;
-use typed_index_collection::*;
 
 #[derive(GetCorresponding)]
 pub struct Model {

--- a/relational_types_procmacro_tests/tests/03-non-supported-argument.stderr
+++ b/relational_types_procmacro_tests/tests/03-non-supported-argument.stderr
@@ -1,7 +1,7 @@
 error: proc-macro derive panicked
- --> $DIR/03-non-supported-argument.rs:7:10
+ --> $DIR/03-non-supported-argument.rs:6:10
   |
-7 | #[derive(GetCorresponding)]
+6 | #[derive(GetCorresponding)]
   |          ^^^^^^^^^^^^^^^^
   |
   = help: message: Only `key = "value"` attributes supported.


### PR DESCRIPTION
The CI badge in the `README.md` is broken since the name of the workflow is incorrect. This should fix it.

This PR also fix some tests that are starting to fail on `beta` build (but it is a valid error).