### PR TITLE
[feature] Make relational_types::Result generic on Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "relational_types"
 description = "Manage relations between objects"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Kisio Digital <team.coretools@kisio.org>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 edition = "2018"
 license = "MIT"

--- a/relational_types_procmacro/Cargo.toml
+++ b/relational_types_procmacro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "relational_types_procmacro"
 description = "Procmacro to help create relations between objects"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Kisio Digital <team.coretools@kisio.org>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 edition = "2018"
 license = "MIT"

--- a/relational_types_procmacro/src/lib.rs
+++ b/relational_types_procmacro/src/lib.rs
@@ -6,7 +6,6 @@
 
 extern crate proc_macro;
 use quote::*;
-use syn;
 
 use proc_macro::TokenStream;
 use std::collections::{HashMap, HashSet};

--- a/src/relations.rs
+++ b/src/relations.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use typed_index_collection::{CollectionWithId, Id, Idx};
 
 /// The corresponding result type used by the crate.
-type Result<T> = std::result::Result<T, Error>;
+type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// A set of `Idx<T>`
 pub type IdxSet<T> = BTreeSet<Idx<T>>;


### PR DESCRIPTION
Related to https://github.com/CanalTP/transit_model/pull/698.