### PR TITLE
[feature] expose mutable API for OneToMany

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "relational_types"
 description = "Manage relations between objects"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Kisio Digital <team.coretools@kisio.org>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
Propose a new function `OneToMany::add_link(&mut self...)` to allow to update a relation (so far, `OneToMany` is immutable and that would make it mutable).