### PR TITLE
[feature] bump to typed_index_collection:v2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "relational_types"
 description = "Manage relations between objects"
-version = "1.1.0"
+version = "2.0.0"
 authors = ["Kisio Digital <team.coretools@kisio.org>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 edition = "2018"
 license = "MIT"
@@ -20,9 +20,9 @@ members = [
 
 [dependencies]
 derivative = "1"
-relational_types_procmacro = { version = "1", path = "./relational_types_procmacro/", optional = true }
+relational_types_procmacro = { version = "2", path = "./relational_types_procmacro/", optional = true }
 thiserror = "1"
-typed_index_collection = "1"
+typed_index_collection = "2"
 
 [features]
 default = ["relational_types_procmacro"]

--- a/relational_types_procmacro/Cargo.toml
+++ b/relational_types_procmacro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "relational_types_procmacro"
 description = "Procmacro to help create relations between objects"
-version = "1.1.0"
+version = "2.0.0"
 authors = ["Kisio Digital <team.coretools@kisio.org>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 edition = "2018"
 license = "MIT"

--- a/relational_types_procmacro_tests/Cargo.toml
+++ b/relational_types_procmacro_tests/Cargo.toml
@@ -9,8 +9,8 @@ autotests = false
 [dev-dependencies]
 pretty_assertions = "0.6"
 trybuild = "1"
-typed_index_collection = "1"
-relational_types = { version = "1", path = "../" }
+typed_index_collection = "2"
+relational_types = { version = "2", path = "../" }
 
 [[test]]
 name = "tests"


### PR DESCRIPTION
Just a bump to `typed_index_collection`. Since this is breaking change bump, I also bump a major version for `relational_types`.